### PR TITLE
Only update rotation if it actually changed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,10 @@ fn rotate_towards(
 
         let rotation = calculate_local_rotation_to_target(rotator_gt, target_gt, parent_gt, updir);
 
-        rotator_t.rotation = rotation;
+        const EPSILON: f32 = 1e-6;
+        if !rotation.abs_diff_eq(rotator_t.rotation, EPSILON) {
+            rotator_t.rotation = rotation;
+        }
     }
 }
 


### PR DESCRIPTION
I don't think there should be any concerns doing this. If the rotation is essentially the same as what it was before, then there's no need to change it.