### PR TITLE
Change insert to try_insert to avoid panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ fn rotate_towards_with_updated_global_transforms(
             continue;
         };
 
-        ec.insert(new_rotator_t);
+        ec.try_insert(new_rotator_t);
     }
 }
 


### PR DESCRIPTION
I was experiencing a panic because this previously queued a command that would panic if the entity was despawned before it tries to insert the new component.

Similar to https://github.com/avianphysics/avian/pull/608 and https://github.com/avianphysics/avian/pull/858.